### PR TITLE
Catch all exception when instanciating a controller

### DIFF
--- a/Basic.php
+++ b/Basic.php
@@ -196,7 +196,7 @@ class Basic extends Dispatcher {
 
                     $controller = dnew($controller, $rtv);
                 }
-                catch ( \Hoa\Core\Exception $e ) {
+                catch ( \Exception $e ) {
 
                     throw new Exception(
                         'Controller %s is not found ' .


### PR DESCRIPTION
This is the fix that replace https://github.com/hoaproject/Core/pull/19
