### PR TITLE
Remove the assumption call+able=controller+action

### DIFF
--- a/Basic.php
+++ b/Basic.php
@@ -164,17 +164,17 @@ class Basic extends Dispatcher {
 
                 if(false === $async) {
 
-                    $_controller = 'synchronous.controller';
-                    $_action     = 'synchronous.action';
+                    $_controller = 'synchronous.call';
+                    $_action     = 'synchronous.able';
                 }
                 else {
 
-                    $_controller = 'asynchronous.controller';
-                    $_action     = 'asynchronous.action';
+                    $_controller = 'asynchronous.call';
+                    $_action     = 'asynchronous.able';
                 }
 
-                $this->_parameters->setKeyword('controller', $controller);
-                $this->_parameters->setKeyword('action',     $action);
+                $this->_parameters->setKeyword('call', $controller);
+                $this->_parameters->setKeyword('able', $action);
 
                 $controller = $this->_parameters->getFormattedParameter($_controller);
                 $action     = $this->_parameters->getFormattedParameter($_action);

--- a/Dispatcher.php
+++ b/Dispatcher.php
@@ -87,16 +87,15 @@ abstract class Dispatcher implements Core\Parameter\Parameterizable {
         $this->_parameters = new Core\Parameter(
             __CLASS__,
             [
-                'controller' => 'main',
-                'action'     => 'main',
-                'method'     => null
+                'call' => 'main',
+                'able' => 'main'
             ],
             [
-                'synchronous.controller'  => 'Application\Controller\(:controller:U:)',
-                'synchronous.action'      => '(:action:U:)Action',
+                'synchronous.call' => '(:call:U:)',
+                'synchronous.able' => '(:able:U:)',
 
-                'asynchronous.controller' => '(:%synchronous.controller:)',
-                'asynchronous.action'     => '(:%synchronous.action:)Async',
+                'asynchronous.call' => '(:%synchronous.call:)',
+                'asynchronous.able' => '(:%synchronous.able:)Async',
 
                 /**
                  * Router variables.
@@ -152,9 +151,7 @@ abstract class Dispatcher implements Core\Parameter\Parameterizable {
         foreach($rule[Router::RULE_VARIABLES] as $key => $value)
             $this->_parameters->setParameter('variables.' . $key, $value);
 
-        $this->_parameters->setKeyword('method', $router->getMethod());
-
-        $out               = $this->resolve($rule, $router, $view);
+        $out = $this->resolve($rule, $router, $view);
         unset($this->_parameters);
         $this->_parameters = $parameters;
 


### PR DESCRIPTION
Related to #11.

We previously assumed that call = controller and able = action. It was a choice guided by the community for more convenience. This choice is kept in the Basic dispatcher, but not in the Dispatcher abstract class.

This PR introduces a BC break: The parameters are not the same and their respective values change. This library is not finalized yet, so we are allowed to do that.

Thoughts?